### PR TITLE
Remove jmx to improve startup time slightly

### DIFF
--- a/AuthMicro/src/main/resources/application.properties
+++ b/AuthMicro/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jmx.enabled=false

--- a/CategoryMicro/src/main/resources/application.properties
+++ b/CategoryMicro/src/main/resources/application.properties
@@ -3,3 +3,4 @@ server.port=10001
 eureka.client.service-url.default-zone=http://localhost:8761/eureka/
 spring.jpa.show-sql=true
 spring.h2.console.enabled=true
+spring.jmx.enabled=false

--- a/GrizLibrary/src/main/resources/application.properties
+++ b/GrizLibrary/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=grizlibrary
+spring.jmx.enabled=false

--- a/ProductMicro/src/main/resources/application.properties
+++ b/ProductMicro/src/main/resources/application.properties
@@ -3,3 +3,4 @@ server.port=10005
 eureka.client.service-url.default-zone=http://localhost:8761/eureka/
 spring.jpa.show-sql=true
 spring.h2.console.enabled=true
+spring.jmx.enabled=false

--- a/UserMicro/src/main/resources/application.properties
+++ b/UserMicro/src/main/resources/application.properties
@@ -3,3 +3,4 @@ server.port=10002
 eureka.client.service-url.default-zone=http://localhost:8761/eureka/
 spring.jpa.show-sql=true
 spring.h2.console.enabled=true
+spring.jmx.enabled=false

--- a/VendorMicro/src/main/resources/application.properties
+++ b/VendorMicro/src/main/resources/application.properties
@@ -3,3 +3,4 @@ server.port=10000
 eureka.client.service-url.default-zone=http://localhost:8761/eureka/
 spring.jpa.show-sql=true
 spring.h2.console.enabled=true
+spring.jmx.enabled=false

--- a/apigatewayserver/src/main/resources/application.yml
+++ b/apigatewayserver/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: apigatewayserver
+spring:
+  jmx:
+    enabled: false
 server:
   port: 8765
 zuul:

--- a/configserver/src/main/resources/application.properties
+++ b/configserver/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=configserver
 server.port=8888
+spring.jmx.enabled=false

--- a/namingserver/src/main/resources/application.properties
+++ b/namingserver/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.application.name=namingserver
 server.port=8761
 eureka.client.register-with-eureka=false
 eureka.client.fetch-registry=false
+spring.jmx.enabled=false


### PR DESCRIPTION
disable jmx which is enabled by default.

slightly slows down spin up time.

we don't make use of this feature.